### PR TITLE
Automatic Release Workflow with DEB and RPM packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,9 +37,9 @@ jobs:
           echo "::set-env name=CURRENT_VERSION::$(echo $branchName)"
 
       - name: SET CURRENT_VERSION branch
-        if: startsWith(github.ref, 'refs/branch/')
+        if: startsWith(github.ref, 'refs/heads/')
         run: |
-          branchName=$(echo $GITHUB_REF  | sed 's/refs\/branch\/release\///')
+          branchName=$(echo $GITHUB_REF  | sed 's/refs\/heads\/release\///')
           echo "::set-env name=CURRENT_VERSION::$(echo $branchName)"
 
       - name: Update local toolchain

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,13 +34,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           branchName=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
-          echo "::set-env name=CURRENT_VERSION::$(echo $branchName)"
+          echo "CURRENT_VERSION=$(echo $branchName)" >> $GITHUB_ENV
 
       - name: SET CURRENT_VERSION branch
         if: startsWith(github.ref, 'refs/heads/')
         run: |
           branchName=$(echo $GITHUB_REF  | sed 's/refs\/heads\/release\///')
-          echo "::set-env name=CURRENT_VERSION::$(echo $branchName)"
+          echo "CURRENT_VERSION=$(echo $branchName)" >> $GITHUB_ENV
 
       - name: Update local toolchain
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    name: "publish"
+
+    # Reference your environment variables
+    environment: cargo
+
+    steps:
+      - uses: actions/checkout@master
+
+      # Use caching to speed up your build
+      - name: Cache publish-action bin
+        id: cache-publish-action
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-publish-action
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+      - uses: actions-rs/toolchain@v1
+        if: steps.cache-publish-action.outputs.cache-hit != 'true'
+        with:
+          toolchain: stable
+
+      - name: Install cargo-deb
+        if: steps.cache-publish-action.outputs.cache-hit != 'true'
+        run: cargo install cargo-deb
+
+      - name: Run cargo publish libprotonup
+        run: cargo publish -p libprotonup
+        env:
+          # This can help you tagging the github repository
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This can help you publish to crates.io
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Run cargo build
+        run: cargo build --release
+
+      - name: Run cargo-deb to build a debian package
+        run: cargo-deb -p protonup-rs --deb-version ${{ github.ref }}
+
+      - name: Run cargo publish binary
+        run: cargo publish -p protonup-rs
+        env:
+          # This can help you tagging the github repository
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This can help you publish to crates.io
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Upload Tar gzed binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/protonup-rs-linux-amd64.tar.gz
+          asset_name: protonup-rs-linux-amd64.tar.gz
+          tag: ${{ github.ref }}
+
+      - name: Upload Ziped binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/protonup-rs-linux-amd64.zip
+          asset_name: protonup-rs-linux-amd64.zip
+          tag: ${{ github.ref }}
+
+      - name: Upload deb package to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: /app/target/debian/protonup-rs_${{ github.ref }}-1_amd64.deb
+          asset_name: /app/target/debian/protonup-rs_${{ github.ref }}-1_amd64.deb
+          tag: ${{ github.ref_name }}
+

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,12 +11,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
-    name: "publish"
-
-    # Reference your environment variables
-    environment: cargo
-
+    name: "Build and Publish Release"
     steps:
       - uses: actions/checkout@master
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,8 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - v*
+    branches:
+      - release/*
 
 jobs:
   release:
@@ -28,36 +30,49 @@ jobs:
           path: ~/.cargo
           key: ${{ runner.os }}-build-${{ env.cache-name }}
 
-      - uses: actions-rs/toolchain@v1
-        if: steps.cache-publish-action.outputs.cache-hit != 'true'
-        with:
-          toolchain: stable
+      - name: SET CURRENT_VERSION tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          branchName=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
+          echo "::set-env name=CURRENT_VERSION::$(echo $branchName)"
+
+      - name: SET CURRENT_VERSION branch
+        if: startsWith(github.ref, 'refs/branch/')
+        run: |
+          branchName=$(echo $GITHUB_REF  | sed 's/refs\/branch\/release\///')
+          echo "::set-env name=CURRENT_VERSION::$(echo $branchName)"
+
+      - name: Update local toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+          rustup install stable
 
       - name: Install cargo-deb
         if: steps.cache-publish-action.outputs.cache-hit != 'true'
         run: cargo install cargo-deb
 
       - name: Run cargo publish libprotonup
-        run: cargo publish -p libprotonup
         env:
           # This can help you tagging the github repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # This can help you publish to crates.io
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --dry-run -p libprotonup
 
       - name: Run cargo build
         run: cargo build --release
 
       - name: Run cargo-deb to build a debian package
-        run: cargo-deb -p protonup-rs --deb-version ${{ github.ref }}
+        run: cargo-deb -p protonup-rs --deb-version $CURRENT_VERSION
 
       - name: Run cargo publish binary
-        run: cargo publish -p protonup-rs
         env:
           # This can help you tagging the github repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # This can help you publish to crates.io
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --dry-run -p protonup-rs
 
       - name: Upload Tar gzed binaries to release
         uses: svenstaro/upload-release-action@v2
@@ -65,7 +80,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/release/protonup-rs-linux-amd64.tar.gz
           asset_name: protonup-rs-linux-amd64.tar.gz
-          tag: ${{ github.ref }}
+          tag: $CURRENT_VERSION
 
       - name: Upload Ziped binaries to release
         uses: svenstaro/upload-release-action@v2
@@ -73,13 +88,13 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/release/protonup-rs-linux-amd64.zip
           asset_name: protonup-rs-linux-amd64.zip
-          tag: ${{ github.ref }}
+          tag: $CURRENT_VERSION
 
       - name: Upload deb package to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: /app/target/debian/protonup-rs_${{ github.ref }}-1_amd64.deb
-          asset_name: /app/target/debian/protonup-rs_${{ github.ref }}-1_amd64.deb
-          tag: ${{ github.ref_name }}
+          file: /app/target/debian/protonup-rs_$CURRENT_VERSION-1_amd64.deb
+          asset_name: /app/target/debian/protonup-rs_$CURRENT_VERSION-1_amd64.deb
+          tag: $CURRENT_VERSION
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,14 +33,16 @@ jobs:
       - name: SET CURRENT_VERSION tag
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          branchName=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
-          echo "CURRENT_VERSION=$(echo $branchName)" >> $GITHUB_ENV
+          branchName=$(echo $GITHUB_REF | sed 's/refs\/tags\///' )
+          # variable CURRENT_VERSION should not have the "v" used in the branch name
+          echo "CURRENT_VERSION=$(echo $branchName | sed 's/v//' )" >> $GITHUB_ENV
 
       - name: SET CURRENT_VERSION branch
         if: startsWith(github.ref, 'refs/heads/')
         run: |
           branchName=$(echo $GITHUB_REF  | sed 's/refs\/heads\/release\///')
-          echo "CURRENT_VERSION=$(echo $branchName)" >> $GITHUB_ENV
+          # variable CURRENT_VERSION should not have the "v" used in the tag
+          echo "CURRENT_VERSION=$(echo $branchName | sed 's/v//' )" >> $GITHUB_ENV
 
       - name: Update local toolchain
         run: |
@@ -62,7 +64,7 @@ jobs:
           # retrieve available versions in crates.io api to skip upload if it was published already
           published_versions=$( curl 'https://crates.io/api/v1/crates/libprotonup' -H 'Accept: */*' |  jq '.versions[].num' )
           exists=false
-          if [[ ${published_versions[@]} =~ $(echo $CURRENT_VERSION | sed 's/v//' )  ]]
+          if [[ ${published_versions[@]} =~ $CURRENT_VERSION  ]]
           then
             exists=true
           fi
@@ -82,7 +84,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/debian/protonup-rs_${{ env.CURRENT_VERSION }}_amd64.deb
           asset_name: protonup-rs_${{ env.CURRENT_VERSION }}-1_amd64.deb
-          tag: ${{ env.CURRENT_VERSION }}
+          tag: v${{ env.CURRENT_VERSION }}
           overwrite: true
           draft: true
 
@@ -98,7 +100,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/release/protonup-rs-linux-amd64.tar.gz
           asset_name: protonup-rs-linux-amd64.tar.gz
-          tag: ${{ env.CURRENT_VERSION }}
+          tag: v${{ env.CURRENT_VERSION }}
           overwrite: true
           draft: true
 
@@ -108,7 +110,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/release/protonup-rs-linux-amd64.zip
           asset_name: protonup-rs-linux-amd64.zip
-          tag: ${{ env.CURRENT_VERSION }}
+          tag: v${{ env.CURRENT_VERSION }}
           overwrite: true
           draft: true
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,16 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      # Use caching to speed up your build
-      - name: Cache publish-action bin
-        id: cache-publish-action
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-publish-action
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
-
       - name: SET CURRENT_VERSION tag
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -50,15 +40,17 @@ jobs:
           rustup component add clippy
           rustup install stable
 
-      - name: Install cargo-deb
-        if: steps.cache-publish-action.outputs.cache-hit != 'true'
+      - name: Install cargo-deb (generate DEB package)
         run: cargo install cargo-deb
+
+      - name: Install Alien for RPM conversion
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y alien dpkg-dev debhelper build-essential
 
       - name: Run cargo publish libprotonup
         env:
-          # This can help you tagging the github repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # This can help you publish to crates.io
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           # retrieve available versions in crates.io api to skip upload if it was published already
@@ -76,14 +68,29 @@ jobs:
         run: cargo build --release
 
       - name: Run cargo-deb to build a debian package
-        run: cargo-deb -p protonup-rs --deb-version $CURRENT_VERSION
+        run: cargo-deb -p protonup-rs --compress-type gzip --deb-version $CURRENT_VERSION
 
-      - name: Upload deb package to release
+      - name: Run Alient to convert the DEB package into a RPM package
+        run: |
+          cd target/debian
+          alien -k --to-rpm protonup-rs_${{ env.CURRENT_VERSION }}_amd64.deb
+
+      - name: Upload DEB package to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/debian/protonup-rs_${{ env.CURRENT_VERSION }}_amd64.deb
           asset_name: protonup-rs_${{ env.CURRENT_VERSION }}-1_amd64.deb
+          tag: v${{ env.CURRENT_VERSION }}
+          overwrite: true
+          draft: true
+
+      - name: Upload RPM package to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/debian/protonup-rs-${{ env.CURRENT_VERSION }}-1.x86_64.rpm
+          asset_name: protonup-rs_${{ env.CURRENT_VERSION }}-1.x86_64.rpm
           tag: v${{ env.CURRENT_VERSION }}
           overwrite: true
           draft: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # This can help you publish to crates.io
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --dry-run -p libprotonup
+        run: |
+          uploadedVersion=$( cargo search libprotonup |  cut -d' ' -f3 )
+          if [ "v$uploadedVersion" != $CURRENT_VERSION]; then
+            cargo publish -p libprotonup
+          fi
 
       - name: Run cargo build
         run: cargo build --release
@@ -108,5 +112,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # This can help you publish to crates.io
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --dry-run -p protonup-rs
-
+        run: |
+          uploadedVersion=$( cargo search protonup-rs |  cut -d' ' -f3 )
+          if [ "v$uploadedVersion" != $CURRENT_VERSION]; then
+            cargo publish -p protonup-rs
+          fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,13 +66,19 @@ jobs:
       - name: Run cargo-deb to build a debian package
         run: cargo-deb -p protonup-rs --deb-version $CURRENT_VERSION
 
-      - name: Run cargo publish binary
-        env:
-          # This can help you tagging the github repository
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # This can help you publish to crates.io
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --dry-run -p protonup-rs
+      - name: Upload deb package to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: /app/target/debian/protonup-rs_$CURRENT_VERSION-1_amd64.deb
+          asset_name: /app/target/debian/protonup-rs_$CURRENT_VERSION-1_amd64.deb
+          tag: $CURRENT_VERSION
+
+      - name: Compress binary release artefacts
+        run: |
+          cd ./target/release
+          zip protonup-rs-linux-amd64.zip protonup-rs
+          tar -czvf protonup-rs-linux-amd64.tar.gz protonup-rs
 
       - name: Upload Tar gzed binaries to release
         uses: svenstaro/upload-release-action@v2
@@ -90,11 +96,11 @@ jobs:
           asset_name: protonup-rs-linux-amd64.zip
           tag: $CURRENT_VERSION
 
-      - name: Upload deb package to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: /app/target/debian/protonup-rs_$CURRENT_VERSION-1_amd64.deb
-          asset_name: /app/target/debian/protonup-rs_$CURRENT_VERSION-1_amd64.deb
-          tag: $CURRENT_VERSION
+      - name: Run cargo publish binary
+        env:
+          # This can help you tagging the github repository
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This can help you publish to crates.io
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --dry-run -p protonup-rs
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,8 +59,14 @@ jobs:
           # This can help you publish to crates.io
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          uploadedVersion=$( cargo search libprotonup |  cut -d' ' -f3 )
-          if [ "v$uploadedVersion" != $CURRENT_VERSION]; then
+          # retrieve available versions in crates.io api to skip upload if it was published already
+          published_versions=$( curl 'https://crates.io/api/v1/crates/libprotonup' -H 'Accept: */*' |  jq '.versions[].num' )
+          exists=false
+          if [[ ${published_versions[@]} =~ $(echo $CURRENT_VERSION | sed 's/v//' )  ]]
+          then
+            exists=true
+          fi
+          if ! ( $exists ) ; then
             cargo publish -p libprotonup
           fi
 
@@ -113,7 +119,15 @@ jobs:
           # This can help you publish to crates.io
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          uploadedVersion=$( cargo search protonup-rs |  cut -d' ' -f3 )
-          if [ "v$uploadedVersion" != $CURRENT_VERSION]; then
+          # retrieve available versions in crates.io api to skip upload if it was published already
+          published_versions=$( curl 'https://crates.io/api/v1/crates/Protonup-rs'  -H 'Accept: */*' |  jq '.versions[].num' )
+          exists=false
+          if [[ ${published_versions[@]} =~ $(echo $CURRENT_VERSION | sed 's/v//' )  ]]
+          then
+            exists=true
+          fi
+          if ! ( $exists ) ; then
             cargo publish -p protonup-rs
           fi
+
+

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,6 +73,7 @@ jobs:
           file: target/debian/protonup-rs_${{ env.CURRENT_VERSION }}_amd64.deb
           asset_name: protonup-rs_${{ env.CURRENT_VERSION }}-1_amd64.deb
           tag: ${{ env.CURRENT_VERSION }}
+          overwrite: true
           draft: true
 
       - name: Compress binary release artefacts
@@ -88,6 +89,7 @@ jobs:
           file: target/release/protonup-rs-linux-amd64.tar.gz
           asset_name: protonup-rs-linux-amd64.tar.gz
           tag: ${{ env.CURRENT_VERSION }}
+          overwrite: true
           draft: true
 
       - name: Upload Ziped binaries to release
@@ -97,6 +99,7 @@ jobs:
           file: target/release/protonup-rs-linux-amd64.zip
           asset_name: protonup-rs-linux-amd64.zip
           tag: ${{ env.CURRENT_VERSION }}
+          overwrite: true
           draft: true
 
       - name: Run cargo publish binary

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,9 +70,10 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: /app/target/debian/protonup-rs_$CURRENT_VERSION-1_amd64.deb
-          asset_name: /app/target/debian/protonup-rs_$CURRENT_VERSION-1_amd64.deb
-          tag: $CURRENT_VERSION
+          file: target/debian/protonup-rs_${{ env.CURRENT_VERSION }}_amd64.deb
+          asset_name: protonup-rs_${{ env.CURRENT_VERSION }}-1_amd64.deb
+          tag: ${{ env.CURRENT_VERSION }}
+          draft: true
 
       - name: Compress binary release artefacts
         run: |
@@ -86,7 +87,8 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/release/protonup-rs-linux-amd64.tar.gz
           asset_name: protonup-rs-linux-amd64.tar.gz
-          tag: $CURRENT_VERSION
+          tag: ${{ env.CURRENT_VERSION }}
+          draft: true
 
       - name: Upload Ziped binaries to release
         uses: svenstaro/upload-release-action@v2
@@ -94,7 +96,8 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/release/protonup-rs-linux-amd64.zip
           asset_name: protonup-rs-linux-amd64.zip
-          tag: $CURRENT_VERSION
+          tag: ${{ env.CURRENT_VERSION }}
+          draft: true
 
       - name: Run cargo publish binary
         env:

--- a/protonup-rs/Cargo.toml
+++ b/protonup-rs/Cargo.toml
@@ -12,12 +12,13 @@ description = "TUI Program for Custom Proton Download and installation written i
 [package.metadata.deb]
 maintainer = "Auyer <auyer@rcpassos.me>"
 copyright = "2024, Auyer <auyer@rcpassos.me>"
-extended-description = "TUI Program for Custom Proton Download and installation written in rust"
+extended-description = "TUI Program used to download, install and manage custom Proton/Wine distributions for Steam and Lutris."
 depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
  ["target/release/protonup-rs", "usr/bin/", "755"],
+ ["../README.md", "usr/share/doc/protonup-rs/README", "644"],
 ]
 
 [dependencies]

--- a/protonup-rs/Cargo.toml
+++ b/protonup-rs/Cargo.toml
@@ -9,6 +9,17 @@ readme = "../README.md"
 
 description = "TUI Program for Custom Proton Download and installation written in rust"
 
+[package.metadata.deb]
+maintainer = "Auyer <auyer@rcpassos.me>"
+copyright = "2024, Auyer <auyer@rcpassos.me>"
+extended-description = "TUI Program for Custom Proton Download and installation written in rust"
+depends = "$auto"
+section = "utility"
+priority = "optional"
+assets = [
+ ["target/release/protonup-rs", "usr/bin/", "755"],
+]
+
 [dependencies]
 
 anyhow = "1.0.81"


### PR DESCRIPTION
This PR adds a GithubActions workflow to:
- Run `cargo-deb` to create a deb package from the cargo definition
- Run `Alien` to convert it into an RPM package
- It uploads the files to the Release with matching TAG
- Publishes a the library and Binary to crates.io (no more manual building for me)

It should be run in a branch `release/v*.*.*` or in a tag. 