### PR TITLE
Bump depencies and prepare to release from Main instead of a release Branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - release/**
 
 jobs:
   release:
@@ -15,17 +13,9 @@ jobs:
       - uses: actions/checkout@master
 
       - name: SET CURRENT_VERSION tag
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           branchName=$(echo $GITHUB_REF | sed 's/refs\/tags\///' )
           # variable CURRENT_VERSION should not have the "v" used in the branch name
-          echo "CURRENT_VERSION=$(echo $branchName | sed 's/v//' )" >> $GITHUB_ENV
-
-      - name: SET CURRENT_VERSION branch
-        if: startsWith(github.ref, 'refs/heads/')
-        run: |
-          branchName=$(echo $GITHUB_REF  | sed 's/refs\/heads\/release\///')
-          # variable CURRENT_VERSION should not have the "v" used in the tag
           echo "CURRENT_VERSION=$(echo $branchName | sed 's/v//' )" >> $GITHUB_ENV
 
       - name: Update local toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -180,9 +180,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "cfg-if"
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
 dependencies = [
  "anstream",
  "anstyle",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -952,7 +952,7 @@ version = "0.8.1"
 dependencies = [
  "anyhow",
  "arcstr",
- "clap 4.5.4",
+ "clap 4.5.6",
  "futures-util",
  "indicatif",
  "inquire",
@@ -1517,9 +1517,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "untrusted"
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vec_map"
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libprotonup"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "protonup-rs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arcstr",

--- a/libprotonup/Cargo.toml
+++ b/libprotonup/Cargo.toml
@@ -27,10 +27,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 structopt = "0.3"
-tokio = { version = "1.37", features = ["macros"] }
+tokio = { version = "1.38", features = ["macros"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
 tokio-tar = "0.3"
 tokio-util = "0.7"
 
 [dev-dependencies]
-tokio = { version = "1.37", features = ["macros", "rt"] }
+tokio = { version = "1.38", features = ["macros", "rt"] }

--- a/libprotonup/Cargo.toml
+++ b/libprotonup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libprotonup"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Auyer <auyer@rcpassos.me>"]
 repository = "https://github.com/auyer/protonup-rs"

--- a/protonup-rs/Cargo.toml
+++ b/protonup-rs/Cargo.toml
@@ -34,5 +34,5 @@ indicatif = { version = "0.17", features = [
     "tokio"
 ] }
 tempfile = "3.10"
-tokio = { version = "1.37", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.38", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.5", features = ["derive"] }

--- a/protonup-rs/Cargo.toml
+++ b/protonup-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protonup-rs"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Auyer <auyer@rcpassos.me>"]
 repository = "https://github.com/auyer/protonup-rs"
@@ -26,7 +26,7 @@ assets = [
 anyhow = "1.0"
 arcstr = "1.2"
 futures-util = "0.3"
-libprotonup = { path = "../libprotonup", version = "0.8.1" }
+libprotonup = { path = "../libprotonup", version = "0.8.2" }
 inquire = { version = "0.7", default-features = false, features = ["termion"] }
 indicatif = { version = "0.17", features = [
     "improved_unicode",


### PR DESCRIPTION
This will make it easier to generate AUR packages for Arch-based distros.
It should also make it easier to release new versions, without the need to create a branch and update the Cargo.lock after releasing.
The Tag should also with with `cargo fetch --frozen`, since the lockfile is no longer behind when releasing (Helps with  #24). 