### PR TITLE
Show installed release on install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libprotonup"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "protonup-rs"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "arcstr",

--- a/libprotonup/src/github.rs
+++ b/libprotonup/src/github.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub type ReleaseList = Vec<Release>;
 
 /// Contains the information from one of the releases on GitHub
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Release {
     /// API URL of the Release
     url: Option<String>,
@@ -50,7 +50,7 @@ impl Release {
 /// Holds the information from the different Assets for each GitHub release
 ///
 /// An Asset could be for the wine tar folder or for the sha512sum
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Asset {
     url: String,
     id: i64,

--- a/protonup-rs/src/main.rs
+++ b/protonup-rs/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
         quick_download,
         force,
     } = Opt::parse();
-    if quick_download {
+    let releases = if quick_download {
         download::run_quick_downloads(force).await
     } else {
         let answer: InitialMenu = Select::new(
@@ -89,7 +89,16 @@ async fn main() {
             InitialMenu::DownloadIntoCustomLocation => {
                 download::download_to_selected_app(None).await
             }
-            InitialMenu::ManageExistingInstallations => manage_apps_routine().await,
+            InitialMenu::ManageExistingInstallations => {
+                manage_apps_routine().await;
+                Ok(vec![])
+            }
+        }
+    };
+
+    if let Ok(releases) = releases {
+        for release in releases {
+            println!("Installed {}", release.tag_name);
         }
     }
 }


### PR DESCRIPTION
After install show a line for each installed release. May be improved by relating the context between the applications and releases. 

```
./target/debug/protonup-rs
> ProtonUp Menu: Choose your action: Quick Update (detect apps and auto download)
Found the following apps: Steam "Native" , Lutris "Native"
Installed GE-Proton9-21
```

Resolves #32 