### PR TITLE
refactor: hashing: refactor to allow different hashing algos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,6 @@ dependencies = [
  "indicatif",
  "inquire",
  "libprotonup",
- "tempfile",
  "tokio",
 ]
 

--- a/libprotonup/Cargo.toml
+++ b/libprotonup/Cargo.toml
@@ -33,8 +33,8 @@ lazy_static = "1.5.0"
 # decompression
 tokio-tar = "0.3"
 async-compression = { version = "0.4", features = ['gzip', 'xz', 'tokio'] }
+tempfile = "3.19"
 
 [dev-dependencies]
-tempfile = "3.19"
 tar = "0.4.44"
 tokio = { version = "1.44", features = ["macros", "rt"] }

--- a/libprotonup/src/hashing.rs
+++ b/libprotonup/src/hashing.rs
@@ -1,0 +1,117 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256, Sha512};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct HashSums {
+    pub sum_content: String,
+    pub sum_type: HashSumType,
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub enum HashSumType {
+    Sha512,
+    Sha256,
+}
+
+/// Checks the downloaded file integrity with the sha512sum
+pub async fn hash_check_file<R: AsyncRead + Unpin + ?Sized>(
+    reader: &mut R,
+    git_hash: HashSums,
+) -> Result<bool> {
+    // TODO: this assumes there is only one file in the checksum
+    let (expected_hash, _) = git_hash
+        .sum_content
+        .as_str()
+        .rsplit_once(' ')
+        .unwrap_or((&git_hash.sum_content, ""));
+
+    match git_hash.sum_type {
+        HashSumType::Sha512 => {
+            let mut hasher = Sha512::new();
+            read_all_into_digest(reader, &mut hasher)
+                .await
+                .context("[Hash Check] Failed reading download file for checking")?;
+
+            let hash = hasher.finalize();
+
+            if hex::encode(hash) != expected_hash.trim() {
+                return Ok(false);
+            }
+            Ok(true)
+        }
+        HashSumType::Sha256 => {
+            let mut hasher = Sha256::new();
+            read_all_into_digest(reader, &mut hasher)
+                .await
+                .context("[Hash Check] Failed reading download file for checking")?;
+
+            let hash = hasher.finalize();
+
+            if hex::encode(hash) != expected_hash.trim() {
+                return Ok(false);
+            }
+            Ok(true)
+        }
+    }
+}
+
+async fn read_all_into_digest<R: AsyncRead + Unpin + ?Sized, D: Digest>(
+    read: &mut R,
+    digest: &mut D,
+) -> Result<()> {
+    const BUFFER_LEN: usize = 8 * 1024; // 8KB
+    let mut buffer = [0u8; BUFFER_LEN];
+
+    loop {
+        let count = read.read(&mut buffer).await?;
+        digest.update(&buffer[..count]);
+        if count != BUFFER_LEN {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use sha2::{Digest, Sha256, Sha512};
+
+    use crate::hashing::{HashSumType, HashSums};
+
+    #[tokio::test]
+    async fn hash_check_file() {
+        let test_data = b"This Is A Test";
+        let hash = hex::encode(Sha512::new_with_prefix(test_data).finalize());
+
+        assert!(
+            super::hash_check_file(
+                &mut &test_data[..],
+                HashSums {
+                    sum_content: hash,
+                    sum_type: HashSumType::Sha512
+                }
+            )
+            .await
+            .unwrap(),
+            "Hash didn't match"
+        );
+
+        let hash = hex::encode(Sha256::new_with_prefix(test_data).finalize());
+
+        assert!(
+            super::hash_check_file(
+                &mut &test_data[..],
+                HashSums {
+                    sum_content: hash,
+                    sum_type: HashSumType::Sha256
+                }
+            )
+            .await
+            .unwrap(),
+            "Hash didn't match"
+        );
+    }
+}

--- a/libprotonup/src/lib.rs
+++ b/libprotonup/src/lib.rs
@@ -2,5 +2,6 @@ pub mod apps;
 pub mod constants;
 pub mod files;
 pub mod github;
+pub mod hashing;
 pub mod sources;
 pub mod utils;

--- a/protonup-rs/Cargo.toml
+++ b/protonup-rs/Cargo.toml
@@ -33,6 +33,5 @@ indicatif = { version = "0.17", features = [
   "unicode-segmentation",
   "tokio",
 ] }
-tempfile = "3.19"
 tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.5.34", features = ["derive"] }


### PR DESCRIPTION
- Splits hashing functions from files module into a new hashing module.
- Adds support to sha256 (it is easy to add other now)
- skips validation if hash not found