### PR TITLE
Fix GE-Proton install for new releases and error logs not printing on error

### DIFF
--- a/libprotonup/src/apps.rs
+++ b/libprotonup/src/apps.rs
@@ -133,10 +133,10 @@ impl AppInstallations {
     pub fn default_install_dir(&self) -> ArcStr {
         match self {
             Self::Steam => {
-                arcstr::ArcStr::from(format!("{}/compatibilitytools.d/", self.app_base_dir()))
+                arcstr::ArcStr::from(format!("{}compatibilitytools.d/", self.app_base_dir()))
             }
             Self::SteamFlatpak => {
-                arcstr::ArcStr::from(format!("{}/compatibilitytools.d/", self.app_base_dir()))
+                arcstr::ArcStr::from(format!("{}compatibilitytools.d/", self.app_base_dir()))
             }
             Self::Lutris => self.app_base_dir(),
             Self::LutrisFlatpak => self.app_base_dir(),

--- a/libprotonup/src/downloads.rs
+++ b/libprotonup/src/downloads.rs
@@ -67,6 +67,7 @@ impl Release {
                     .download_url
                     .clone_from(&asset.browser_download_url);
                 download.size = asset.size as u64;
+                break;
             }
         }
         download

--- a/protonup-rs/src/download.rs
+++ b/protonup-rs/src/download.rs
@@ -1,9 +1,9 @@
-use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow, bail};
 use futures_util::stream::FuturesUnordered;
 use futures_util::{StreamExt, future, stream};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use inquire::{Select, Text};
+use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::fs::{File, OpenOptions};
 use tokio::io::BufReader;
@@ -318,12 +318,16 @@ pub async fn download_to_selected_app(app: Option<apps::App>) -> Result<Vec<Rele
         let progress = multi_progress.clone();
         let tool = selected_tool.clone();
         let app_inst = app_inst.clone();
-        tokio::spawn(async move {
-            download_validate_unpack(release, app_inst, tool, progress).await
-        })
+        tokio::spawn(
+            async move { download_validate_unpack(release, app_inst, tool, progress).await },
+        )
     });
 
-    for task in tasks.collect::<FuturesUnordered<_>>().collect::<Vec<_>>().await {
+    for task in tasks
+        .collect::<FuturesUnordered<_>>()
+        .collect::<Vec<_>>()
+        .await
+    {
         let err: Option<anyhow::Error> = match task {
             Ok(Ok(())) => None,
             Ok(Err(e)) => Some(e),

--- a/protonup-rs/src/download.rs
+++ b/protonup-rs/src/download.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
-
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use futures_util::stream::FuturesUnordered;
 use futures_util::{StreamExt, future, stream};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -124,10 +123,7 @@ pub(crate) async fn validate_file(
     )
     .await?
     {
-        return Err(anyhow::Error::msg(format!(
-            "{} failed validation",
-            path.display()
-        )));
+        bail!("{} failed validation", path.display());
     }
 
     hash_progress_bar.set_style(get_message_bar_style().await);
@@ -317,24 +313,28 @@ pub async fn download_to_selected_app(app: Option<apps::App>) -> Result<Vec<Rele
 
     let multi_progress = MultiProgress::with_draw_target(ProgressDrawTarget::stderr_with_hz(20));
 
-    stream::iter(releases.clone())
-        .map(|release| {
-            let progress = multi_progress.clone();
-            let tool = selected_tool.clone();
-            let app_inst = app_inst.clone();
-            tokio::spawn(async move {
-                download_validate_unpack(release, app_inst, tool, progress).await
-            })
+    let tasks = releases.iter().map(|release| {
+        let release = release.clone();
+        let progress = multi_progress.clone();
+        let tool = selected_tool.clone();
+        let app_inst = app_inst.clone();
+        tokio::spawn(async move {
+            download_validate_unpack(release, app_inst, tool, progress).await
         })
-        .collect::<FuturesUnordered<_>>()
-        .await
-        .for_each(|res| {
-            if let Err(e) = res {
-                multi_progress.println(format!("{}", e)).unwrap();
-            }
-            future::ready(())
-        })
-        .await;
+    });
+
+    for task in tasks.collect::<FuturesUnordered<_>>().collect::<Vec<_>>().await {
+        let err: Option<anyhow::Error> = match task {
+            Ok(Ok(())) => None,
+            Ok(Err(e)) => Some(e),
+            Err(join_err) => Some(anyhow!(join_err)),
+        };
+
+        if let Some(e) = err {
+            eprintln!("{}", e);
+            return Err(anyhow!("Installation failed with Error"));
+        }
+    }
 
     Ok(releases)
 }

--- a/protonup-rs/src/download.rs
+++ b/protonup-rs/src/download.rs
@@ -409,7 +409,7 @@ async fn download_validate_unpack(
 
     unpack_progress_bar.set_style(get_message_bar_style().await);
     unpack_progress_bar.finish_with_message(format!(
-        "Done! {} installed in {}{}\nYour app might require a restart to detect {}",
+        "Done! {} installed in {}/{}\nYour app might require a restart to detect {}",
         compat_tool,
         download
             .for_app

--- a/protonup-rs/src/main.rs
+++ b/protonup-rs/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 use inquire::Select;
 
-use std::fmt;
+use std::{fmt, process::exit};
 
 use libprotonup::apps::App;
 
@@ -99,9 +99,15 @@ async fn main() {
         }
     };
 
-    if let Ok(releases) = releases {
-        for release in releases {
-            println!("Installed {}", release.tag_name);
+    match releases {
+        Ok(releases) => {
+            for release in releases {
+                println!("Installed {}", release.tag_name);
+            }
+        }
+        Err(e) => {
+            eprintln!("{}", e);
+            exit(1);
         }
     }
 }


### PR DESCRIPTION
Fix for https://github.com/auyer/Protonup-rs/issues/54 and error logs not printing on error and minor fixes for paths logging (visual stuff)

The "fix" for the issue itself is in last commit, simple "break". Still it's not a real fix as future proof fix would actually change the way checksum validation is happening for GE releases. Would Eggroll change the order of files that are uploaded on release issue will come back. Still this time at least it will be printed thanks to other changes :D 

This is my second pull request ever so sorry in advance :p 